### PR TITLE
Fix settings validation when using environment variables

### DIFF
--- a/src/models/SettingsModel.php
+++ b/src/models/SettingsModel.php
@@ -191,6 +191,16 @@ class SettingsModel extends Model
         return md5(json_encode($this->lambdaConfig()));
     }
 
+    public function behaviors(): array
+    {
+        return [
+            'parser' => [
+                'class' => EnvAttributeParserBehavior::class,
+                'attributes' => ['awsResourcePrefix', 'rootPrefix'],
+            ],
+        ];
+    }
+
     protected function defineRules(): array
     {
         return [


### PR DESCRIPTION
Settings validation fails for AWS Resource Prefix (`awsResourcePrefix`) and S3 Root Prefix (`rootPrefix`) when using environment variables. Per [Craft Documentation](https://craftcms.com/docs/4.x/extend/environmental-settings.html#validation) using the `behaviors` method will allow the plugin to pre-parse the value of the environment variable for use in validating the setting.