### PR TITLE
Address malformed deleteObject request

### DIFF
--- a/src/services/S3.php
+++ b/src/services/S3.php
@@ -194,6 +194,11 @@ class S3 extends Component
 
     public function deleteObjects(array $paths): void
     {
+        if ( count($paths) == 0 ) {
+            Craft::warning('Skipping Flux purge: no asset paths provided.', __METHOD__);
+            return;
+        }
+        
         /* @var SettingsModel */
         $settings = Flux::getInstance()->getSettings();
 


### PR DESCRIPTION
If an empty Objects array is sent in a `deleteObjects` request, AWS will respond with a malformed request error. This update verifies that the number of asset paths to delete is non-zero before proceeding with the `deleteObjects` request; if there are no paths to delete, a warning is logged.

Fixes #6