### PR TITLE
Add global AWS resource prefix to settings

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -44,6 +44,9 @@ return [
         // Prefix for auto generated AWS resources
         // 'awsResourcePrefix' => 'Flux',
 
+        // Prefix for auto generated global AWS resources (optional)
+        // 'awsGlobalResourcePrefix' => '',
+
         // S3 Bucket name
         // 'awsBucket' => '',
 

--- a/src/models/SettingsModel.php
+++ b/src/models/SettingsModel.php
@@ -53,6 +53,11 @@ class SettingsModel extends Model
     public string $awsResourcePrefix = "Flux";
 
     /**
+     * @var string Prefix for auto generated global AWS resources
+     */
+    public string $awsGlobalResourcePrefix = "";
+
+    /**
      * @var string Bucket selection mode ('choose' or 'manual')
      */
     public string $bucketSelectionMode = 'choose';
@@ -196,7 +201,7 @@ class SettingsModel extends Model
         return [
             'parser' => [
                 'class' => EnvAttributeParserBehavior::class,
-                'attributes' => ['awsAccessKeyId', 'awsSecretAccessKey', 'awsResourcePrefix', 'rootPrefix'],
+                'attributes' => ['awsAccessKeyId', 'awsSecretAccessKey', 'awsGlobalResourcePrefix', 'awsResourcePrefix', 'rootPrefix'],
             ],
         ];
     }
@@ -205,7 +210,7 @@ class SettingsModel extends Model
     {
         return [
             [['awsAccessKeyId', 'awsSecretAccessKey'], 'required'],
-            [['awsResourcePrefix', 'rootPrefix'], 'match', 'pattern' => '/^[a-zA-Z0-9\-]*$/i'],
+            [['awsGlobalResourcePrefix', 'awsResourcePrefix', 'rootPrefix'], 'match', 'pattern' => '/^[a-zA-Z0-9\-]*$/i'],
             [['jpegQuality', 'webpQuality'], 'number', 'min' => 1, 'integerOnly' => true, 'max' => 100],
             [['lambdaMemory'], 'number', 'min' => 128, 'integerOnly' => true, 'max' => 10240],
             [['lambdaTimeout'], 'number', 'min' => 3, 'integerOnly' => true, 'max' => 900],

--- a/src/services/Lambda.php
+++ b/src/services/Lambda.php
@@ -241,7 +241,9 @@ class Lambda extends Component
     {
         /* @var SettingsModel */
         $settings = Flux::getInstance()->getSettings();
-        $prefix = App::parseEnv($settings->awsResourcePrefix);
+        $globalPrefix = App::parseEnv($settings->awsGlobalResourcePrefix) !== '' ?
+            App::parseEnv($settings->awsGlobalResourcePrefix) :
+            App::parseEnv($settings->awsResourcePrefix);
         $distributionId = App::parseEnv($settings->cloudFrontDistributionId);
 
         $functions = [
@@ -264,8 +266,8 @@ class Lambda extends Component
 
         $cloudfront = Flux::getInstance()->cloudfront->client();
 
-        $cachePolicyId = Flux::getInstance()->cloudfront->updateCachePolicy("$prefix-Cache-Policy");
-        $originRequestPolicyId = Flux::getInstance()->cloudfront->updateOriginRequestPolicy("$prefix-Origin-Request-Policy");
+        $cachePolicyId = Flux::getInstance()->cloudfront->updateCachePolicy("$globalPrefix-Cache-Policy");
+        $originRequestPolicyId = Flux::getInstance()->cloudfront->updateOriginRequestPolicy("$globalPrefix-Origin-Request-Policy");
 
         $distribution = $cloudfront->getDistribution(['Id' => $distributionId]);
 

--- a/src/templates/_settings/aws.twig
+++ b/src/templates/_settings/aws.twig
@@ -45,6 +45,20 @@
   })
 }}
 
+{{
+  forms.autosuggestField({
+    label: 'AWS Global Resource Prefix (optional)'|t('flux'),
+    instructions: 'Prefix for auto generated resources that are reusable between multiple Flux-enabled sites that share an AWS account.'|t(
+      'flux'
+    ),
+    suggestEnvVars: true,
+    name: 'settings[awsGlobalResourcePrefix]',
+    value: settings.awsGlobalResourcePrefix,
+    required: false,
+    errors: settings.getErrors('awsGlobalResourcePrefix')
+  })
+}}
+
 {% set bucketInput %}
   <div class="flex fullwidth">
     {{


### PR DESCRIPTION
The quantity of Cache Policies and Origin Request Policies are strictly limited to 20 per AWS account. AWS does not provide a means to alter the quota for these resources. If you manage multiple Flux-enabled projects under one AWS account, you run the risk of exceeding your quota.

To avoid this, these resources should be created using a "global" resource prefix, so that they are shared between all Flux-enabled sites. In this update, a new settings variable called `awsGlobalResourcePrefix` has been added. If no global resource prefix is provided, these quota-restricted resources will be created using the standard AWS resource prefix defined in settings. With this fallback in place, backwards compatibility is maintained -- no existing users of the Flux plugin will need to alter their settings.

With the addition of a "global" scope to AWS resources created by Flux there is one item that should be considered as the plugin is updated: These global resources MUST NOT be removed by Flux when it is uninstalled. Future versions of Flux should take this into account, if a "cleanup" of AWS resources is ever introduced as a feature of the plugin.

Fixes #8 