### PR TITLE
Resolve issue in CreateFunction due to architecture validation error

### DIFF
--- a/src/services/Lambda.php
+++ b/src/services/Lambda.php
@@ -156,7 +156,7 @@ class Lambda extends Component
         $functionVersion = Flux::getInstance()->version;
 
         $config = array_merge([
-            'Architectures' => ['x86-64'],
+            'Architectures' => ['x86_64'],
             'FunctionName' => $name,
             'Description' => "Deployed by Flux v$functionVersion $configHash",
             'Runtime' => 'nodejs20.x'


### PR DESCRIPTION
When attempting to install/update to AWS, the command fails with the following error:

```Error executing "CreateFunction" on "https://lambda.us-east-1.amazonaws.com/2015-03-31/functions"; AWS HTTP error: Client error: `POST https://lambda.us-east-1.amazonaws.com/2015-03-31/functions` resulted in a `400 Bad Request` response: {"message":"1 validation error detected: Value '[x86-64]' at 'architectures' failed to satisfy constraint: Member must s (truncated...) ValidationException (client): 1 validation error detected: Value '[x86-64]' at 'architectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64], Member must not be null] - {"message":"1 validation error detected: Value '[x86-64]' at 'architectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64], Member must not be null]"}```

The AWS Lambda CreateFunction expects a value of `x86_64` for the architecture, while Flux is providing `x86-64`.